### PR TITLE
Ensure we call finish on the response

### DIFF
--- a/rack-async-http-falcon-graphql-batch/async_loader.rb
+++ b/rack-async-http-falcon-graphql-batch/async_loader.rb
@@ -10,8 +10,13 @@ class AsyncLoader < GraphQL::Batch::Loader
     urls.each do |url|
       barrier.async do
         Console.logger.info "AsyncHttp#get: #{url}"
-        body = JSON.parse(internet.get(url).read)
-        fulfill(url, body)
+        begin
+          response = internet.get(url)
+          body = JSON.parse(response.read)
+          fulfill(url, body)
+        ensure
+          response.finish
+        end
         Console.logger.info "AsyncHttp#fulfill: #{url}"
       end
     end

--- a/rack-async-http-falcon-graphql-dataloader/async_loader.rb
+++ b/rack-async-http-falcon-graphql-dataloader/async_loader.rb
@@ -13,8 +13,13 @@ class AsyncLoader < GraphQL::Dataloader::Source
       urls.each do |url|
         barrier.async do
           Console.logger.info "AsyncHttp#get: #{url}"
-          body = JSON.parse(internet.get(url).read)
-          values << body
+          begin
+            response = internet.get(url)
+            body = JSON.parse(response.read)
+            values << body
+          ensure
+            response.finish
+          end
           Console.logger.info "AsyncHttp#fulfill: #{url}"
         end
       end

--- a/rack-async-http-falcon-graphql-lazy-resolve-async-await/query.rb
+++ b/rack-async-http-falcon-graphql-lazy-resolve-async-await/query.rb
@@ -36,7 +36,13 @@ class Query < GraphQL::Schema::Object
     delay_1_semaphore.async do |task|
       @_delay_1_data ||= begin
         Console.logger.measure(self, "delay_1_data") do
-          JSON.parse(internet.get("https://httpbin.org/delay/1").read)
+          begin
+            response = internet.get("https://httpbin.org/delay/1")
+            JSON.parse(response.read)
+          ensure
+            response.finish
+            puts "1"
+          end
         end
       end
     end.wait
@@ -46,7 +52,12 @@ class Query < GraphQL::Schema::Object
     delay_2_semaphore.async do |task|
       @_delay_2_data ||= begin
         Console.logger.measure(self, "delay_2_data") do
-          JSON.parse(internet.get("https://httpbin.org/delay/2").read)
+          begin
+            response = internet.get("https://httpbin.org/delay/2")
+            JSON.parse(response.read)
+          ensure
+            response.finish
+          end
         end
       end
     end.wait

--- a/rack-async-http-falcon-graphql-lazy-resolve-async-await/query.rb
+++ b/rack-async-http-falcon-graphql-lazy-resolve-async-await/query.rb
@@ -41,7 +41,6 @@ class Query < GraphQL::Schema::Object
             JSON.parse(response.read)
           ensure
             response.finish
-            puts "1"
           end
         end
       end

--- a/rack-async-http-falcon-graphql-lazy-resolve/query.rb
+++ b/rack-async-http-falcon-graphql-lazy-resolve/query.rb
@@ -33,7 +33,12 @@ class Query < GraphQL::Schema::Object
     delay_1_semaphore.async do |task|
       @_delay_1_data ||= begin
         Console.logger.measure(self, "delay_1_data") do
-          JSON.parse(internet.get("https://httpbin.org/delay/1").read)
+          begin
+            response = internet.get("https://httpbin.org/delay/1")
+            JSON.parse(response.read)
+          ensure
+            response.finish
+          end
         end
       end
     end.wait
@@ -43,7 +48,12 @@ class Query < GraphQL::Schema::Object
     delay_2_semaphore.async do |task|
       @_delay_2_data ||= begin
         Console.logger.measure(self, "delay_2_data") do
-          JSON.parse(internet.get("https://httpbin.org/delay/2").read)
+          begin
+            response = internet.get("https://httpbin.org/delay/2")
+            JSON.parse(response.read)
+          ensure
+            response.finish
+          end
         end
       end
     end.wait

--- a/rack-async-http-falcon-graphql/async_loader.rb
+++ b/rack-async-http-falcon-graphql/async_loader.rb
@@ -10,8 +10,13 @@ class AsyncLoader < GraphQL::Batch::Loader
     urls.each do |url|
       barrier.async do
         Console.logger.info "AsyncHttp#get: #{url}"
-        body = JSON.parse(internet.get(url).read)
-        fulfill(url, body)
+        begin
+          response = internet.get(url)
+          body = JSON.parse(response.read)
+          fulfill(url, body)
+        ensure
+          response.finish
+        end
         Console.logger.info "AsyncHttp#fulfill: #{url}"
       end
     end

--- a/rack-async-http-falcon-gzip/app.rb
+++ b/rack-async-http-falcon-gzip/app.rb
@@ -18,8 +18,12 @@ class App
       ["user-agent", "example"],
     ]
 
-    response = internet.get(url, headers)
-    body = JSON.parse(response.read)
+    begin
+      response = internet.get(url, headers)
+      body = JSON.parse(response.read)
+    ensure
+      response.finish
+    end
 
     [200, {}, [body.to_json]]
   end

--- a/rack-async-http-puma-graphql/async_loader.rb
+++ b/rack-async-http-puma-graphql/async_loader.rb
@@ -12,8 +12,13 @@ class AsyncLoader < GraphQL::Batch::Loader
       urls.each do |url|
         barrier.async do
           Console.logger.info "AsyncHttp#get: #{url}"
-          body = JSON.parse(internet.get(url).read)
-          fulfill(url, body)
+          begin
+            response = internet.get(url)
+            body = JSON.parse(response.read)
+            fulfill(url, body)
+          ensure
+            response.finish
+          end
           Console.logger.info "AsyncHttp#fulfill: #{url}"
         end
       end

--- a/rails-async-http-falcon-graphql-batch/app/models/async_loader.rb
+++ b/rails-async-http-falcon-graphql-batch/app/models/async_loader.rb
@@ -4,14 +4,19 @@ require "async/http/internet/instance"
 
 class AsyncLoader < GraphQL::Batch::Loader
   def perform(urls)
-    barrier = Async::Barrier.new
     internet = Async::HTTP::Internet.instance
+    barrier = Async::Barrier.new
 
     urls.each do |url|
       barrier.async do
         Console.logger.info "AsyncHttp#get: #{url}"
-        body = JSON.parse(internet.get(url).read)
-        fulfill(url, body)
+        begin
+          response = internet.get(url)
+          body = JSON.parse(response.read)
+          fulfill(url, body)
+        ensure
+          response.finish
+        end
         Console.logger.info "AsyncHttp#fulfill: #{url}"
       end
     end


### PR DESCRIPTION
If the application code has an exception while the `response` hasn't been `finish`ed, it can cause memory leaks. So, let's `ensure` that we always call `response.finish` just in case. 

@ioquatix please let me know if this looks correct to you. Thanks!