### PR TITLE
update puma readme and benchmarks

### DIFF
--- a/rack-async-http-puma-graphql/README.md
+++ b/rack-async-http-puma-graphql/README.md
@@ -12,9 +12,58 @@ Notes:
 
 Running and benchmarking:
 
-    puma -t 1
+    puma -w 5 -t 1:10 --preload
     ab -n 100 -c 100 http://0.0.0.0:9292/
 
 Benchmark results:
 
-  * It's slow...
+Results from MacBook Pro (15-inch, 2018)
+  * 2.6 GHz 6-Core Intel Core i7
+  * 32 GB 2400 MHz DDR4
+
+```
+ab -n 100 -c 100 http://0.0.0.0:9292/
+
+This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
+Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
+Licensed to The Apache Software Foundation, http://www.apache.org/
+
+Benchmarking 0.0.0.0 (be patient).....done
+
+
+Server Software:
+Server Hostname:        0.0.0.0
+Server Port:            9292
+
+Document Path:          /
+Document Length:        120 bytes
+
+Concurrency Level:      100
+Time taken for tests:   9.309 seconds
+Complete requests:      100
+Failed requests:        0
+Total transferred:      16000 bytes
+HTML transferred:       12000 bytes
+Requests per second:    10.74 [#/sec] (mean)
+Time per request:       9308.814 [ms] (mean)
+Time per request:       93.088 [ms] (mean, across all concurrent requests)
+Transfer rate:          1.68 [Kbytes/sec] received
+
+Connection Times (ms)
+              min  mean[+/-sd] median   max
+Connect:        0    4   1.7      4       7
+Processing:  2280 3587 1411.2   2588    7028
+Waiting:     2273 3585 1412.3   2588    7027
+Total:       2280 3591 1411.7   2589    7030
+
+Percentage of the requests served within a certain time (ms)
+  50%   2589
+  66%   4614
+  75%   4615
+  80%   4615
+  90%   4706
+  95%   6857
+  98%   6858
+  99%   7030
+ 100%   7030 (longest request)
+```


### PR DESCRIPTION
Running Puma in a single worker/thread caused slow performance... Updated to utilized multiple workers and threads.

with previous single thread run, my prior results were extremely slow, see below for previous result before updating to leverage workers and threads.

```
ab -n 100 -c 100 http://0.0.0.0:9292/

This is ApacheBench, Version 2.3 <$Revision: 1879490 $>
Copyright 1996 Adam Twiss, Zeus Technology Ltd, http://www.zeustech.net/
Licensed to The Apache Software Foundation, http://www.apache.org/

Benchmarking 0.0.0.0 (be patient).....done


Server Software:
Server Hostname:        0.0.0.0
Server Port:            9292

Document Path:          /
Document Length:        120 bytes

Concurrency Level:      100
Time taken for tests:   230.794 seconds
Complete requests:      100
Failed requests:        0
Total transferred:      16000 bytes
HTML transferred:       12000 bytes
Requests per second:    0.43 [#/sec] (mean)
Time per request:       230794.121 [ms] (mean)
Time per request:       2307.941 [ms] (mean, across all concurrent requests)
Transfer rate:          0.07 [Kbytes/sec] received

Connection Times (ms)
              min  mean[+/-sd] median   max
Connect:        0    3   1.7      4       7
Processing:  2217 114501 67437.9 115926  228552
Waiting:     2217 114501 67438.0 115926  228552
Total:       2224 114505 67436.4 115930  228553

Percentage of the requests served within a certain time (ms)
  50%  115930
  66%  153112
  75%  174321
  80%  185643
  90%  208255
  95%  219570
  98%  226337
  99%  228553
 100%  228553 (longest request)
```
